### PR TITLE
Entry line now displays correctly for all iOS screen sizes

### DIFF
--- a/FormsToolkit/FormsToolkit.iOS/Controls/EntryLineRenderer.cs
+++ b/FormsToolkit/FormsToolkit.iOS/Controls/EntryLineRenderer.cs
@@ -68,7 +68,7 @@ namespace FormsToolkit.iOS
         {
             var borderLayer = new CALayer ();
             borderLayer.MasksToBounds = true;
-            borderLayer.Frame = new CoreGraphics.CGRect (0f, Frame.Height / 2, Frame.Width, 1f);
+            borderLayer.Frame = new CoreGraphics.CGRect(0f, Frame.Height / 2, UIScreen.MainScreen.Bounds.Width, 1f);
             borderLayer.BorderColor = view.BorderColor.ToCGColor ();
             borderLayer.BorderWidth = 1.0f;
 

--- a/ToolkitTests/ToolkitTests/ToolkitTests.cs
+++ b/ToolkitTests/ToolkitTests/ToolkitTests.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-
+using FormsToolkit;
 using Xamarin.Forms;
 
 namespace ToolkitTests
@@ -15,6 +15,14 @@ namespace ToolkitTests
                 Command = new Command(()=>MainPage.Navigation.PushAsync(new MessagingServicePage()))
             };
 
+			var line = new EntryLine
+			{
+				Placeholder = "This nifty place for entering text!",
+				HorizontalTextAlignment = TextAlignment.Center,
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				Text = "",
+				BorderColor = Color.FromHex("#ECECEC")
+			};
 
             // The root page of your application
             MainPage = new NavigationPage(new ContentPage

--- a/ToolkitTests/ToolkitTests/ToolkitTests.cs
+++ b/ToolkitTests/ToolkitTests/ToolkitTests.cs
@@ -30,9 +30,11 @@ namespace ToolkitTests
                 Content = new StackLayout
                 {
                     VerticalOptions = LayoutOptions.Center,
+					Padding = new Thickness(32,32,32,32),
                     Children =
                     {
-                        messagingCenter
+                        messagingCenter,
+						line
                     }
                 }
             });

--- a/ToolkitTests/iOS/AppDelegate.cs
+++ b/ToolkitTests/iOS/AppDelegate.cs
@@ -14,6 +14,8 @@ namespace ToolkitTests.iOS
         {
             global::Xamarin.Forms.Forms.Init();
 
+			FormsToolkit.iOS.Toolkit.Init();
+
             LoadApplication(new App());
 
             return base.FinishedLaunching(app, options);


### PR DESCRIPTION
Instead of using the frame width which was limited, now calculations are being done from the actual device screen size.  Tested on iPads and iPhones with all layouts.
